### PR TITLE
support empty arrays and empty maps

### DIFF
--- a/set_reflect.go
+++ b/set_reflect.go
@@ -272,6 +272,9 @@ func reflectArray(field map[string]interface{}, tag string) ([]interface{}, erro
 		return nil, fmt.Errorf("fsevent: %s is not array", tag)
 	}
 	iv := am["values"]
+	if iv == nil {
+		return nil, nil
+	}
 	vs, ok := iv.([]interface{})
 	if !ok {
 		return nil, fmt.Errorf("fsevent: %s is not array", tag)
@@ -285,6 +288,9 @@ func reflectMap(field map[string]interface{}, tag string) (map[string]interface{
 		return nil, fmt.Errorf("fsevent: %s is not map", tag)
 	}
 	fs := mv["fields"]
+	if fs == nil {
+		return nil, nil
+	}
 	fsm, ok := fs.(map[string]interface{})
 	if !ok {
 		return nil, fmt.Errorf("fsevent: %s is not map", tag)

--- a/value_test.go
+++ b/value_test.go
@@ -201,6 +201,12 @@ var dataToTests = []dataToTest{
 			},
 			"bytes": {
 				"bytesValue": "dGhpcyBpcyBieXRlcy4="
+			},
+			"arrstr": {
+				"arrayValue": {}
+			},
+			"structmap": {
+				"mapValue": {}
 			}
 		}}`,
 		data{


### PR DESCRIPTION
Fix the data structure of Value.Fields in the case of empty arrays
and empty map.
fix #15